### PR TITLE
Fix error: unable to find mod/stickynotes/js/sortable.min

### DIFF
--- a/view.php
+++ b/view.php
@@ -67,7 +67,7 @@ $PAGE->set_title(format_string($moduleinstance->name));
 $PAGE->set_heading(format_string($course->fullname));
 $PAGE->set_context($modulecontext);
 
-$config = ['paths' => ['sortablejs' => '/mod/stickynotes/js/sortable.min']];
+$config = ['paths' => ['sortablejs' => $CFG->wwwroot .'/mod/stickynotes/js/sortable.min']];
 $requirejs = 'require.config(' . json_encode($config) . ')';
 $PAGE->requires->js_amd_inline($requirejs);
 


### PR DESCRIPTION
When Moodle is installed inside a folder, and not directly on a domain URL