### PR TITLE
Fix param key 'modname' in privacy provider

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -148,7 +148,7 @@ class provider implements
 
         $params = [
             'instanceid'    => $context->instanceid,
-            'modulename'    => 'stickynotes',
+            'modname'    => 'stickynotes',
         ];
 
         // Notes authors.


### PR DESCRIPTION
Fixes #34

Changes param key 'modulename' to 'modname' that is expected in add_from_sql during unit tests