### PR TITLE
Upgrade to Moodle version 5.1

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -24,10 +24,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once(dirname(__FILE__) . '/../../config.php');
-require_once("$CFG->libdir/formslib.php");
-require_once("{$CFG->dirroot}/lib/navigationlib.php");
-global $COURSE, $OUTPUT, $PAGE, $CFG;;
+global $CFG;
+require_once($CFG->libdir . '/formslib.php');
+
+global $COURSE, $OUTPUT, $PAGE;
 
 
 /**

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->requires = 2025041400;
+$plugin->requires = 2025100600;
 $plugin->component = 'mod_stickynotes';
-$plugin->release = '0.6.0';
-$plugin->version = 2025060401;
+$plugin->release = '0.7.0';
+$plugin->version = 2025112100;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Besides changes to version, removed imports that are no longer required in Moodle 5.1.