### PR TITLE
Fix the deprecated Bootstrap class float-right to float-end in Moodle 5.1

### DIFF
--- a/templates/notes_list.mustache
+++ b/templates/notes_list.mustache
@@ -141,7 +141,7 @@
     <div id="addcolumn">
     {{#capability_managecolumn}}
         <a href="{{createcolumnurl}}">
-        <i class="fa fa-plus-square fa-2x float-right" title="{{#str}}create_column_pix, stickynotes{{/str}}"></i>
+        <i class="fa fa-plus-square fa-2x float-end" title="{{#str}}create_column_pix, stickynotes{{/str}}"></i>
         </a>
     {{/capability_managecolumn}}
     </div>


### PR DESCRIPTION
## Fixes
- https://github.com/oliviervalentin/moodle-mod_stickynotes/issues/55

## Description 

Update a deprecated Bootstrap class to ensure compatibility with **Moodle 5.1 (Bootstrap 5)**.

**File:**
`stickynotes/templates/notes_list.mustache`

**Line to change:**

```html
<i class="fa fa-plus-square fa-2x float-right" title="{{#str}}create_column_pix, stickynotes{{/str}}"></i>
```

**Change:**
Replace the deprecated class `float-right` with `float-end`.

**Updated line:**

```html
<i class="fa fa-plus-square fa-2x float-end" title="{{#str}}create_column_pix, stickynotes{{/str}}"></i>
```

**Reason:**
Bootstrap 5 (used by Moodle 5.1) removed the `.float-right` class and replaced it with `.float-end`. The current code triggers the warning:

`DEPRECATED STYLE IN USE (.FLOAT-RIGHT)`

This change aligns the plugin with Bootstrap 5 standards and removes the deprecation warning without affecting functionality.

https://moodledev.io/docs/4.5/guides/bs5migration

<img width="768" height="256" alt="image" src="https://github.com/user-attachments/assets/14bb549b-4d7d-4361-ad37-27bc5ce8826c" />